### PR TITLE
MC_42: Mountain chart disappears in full screen page#261 and PA_50: “Fullscreen page” link is not working properly. #269 has been done

### DIFF
--- a/preview_src/templates/layouts/fullscreen.hbs
+++ b/preview_src/templates/layouts/fullscreen.hbs
@@ -47,10 +47,6 @@ control_buttons: {play: true, language: true}
           },
           ui: {
             buttons: {{{chart_buttons}}}
-          },
-          data: {
-            reader: "csv-file",
-            path: "../local_data/waffles/en/basic-indicators.csv"
           }
         });
 

--- a/src/vizabi_custom/gapminder.js
+++ b/src/vizabi_custom/gapminder.js
@@ -247,7 +247,7 @@
         },
         language: language,
         data: {
-            reader: "waffle-server",
+            reader: "waffle-server"
             //reader: "csv-file",
             //path: "local_data/waffles/{{LANGUAGE}}/mountains-pop-gdp-gini.csv"
         }
@@ -454,7 +454,7 @@
         },
 
         data: {
-            reader: "waffle-server",
+            reader: "waffle-server"
         },
         language: language,
         ui: {
@@ -605,7 +605,7 @@
         },
         data: {
             reader: "csv-file",
-            path: "local_data/csv/{{geo}}.csv"
+            path: "/local_data/csv/{{geo}}.csv"
         },
         language: language,
         ui: {


### PR DESCRIPTION
Fixed bug with desappearing of chart on fullscreen page for Mountain chart and PopByAge chart