### PR TITLE
Url parse fix for Firefox

### DIFF
--- a/preview_src/assets/js/_url.js
+++ b/preview_src/assets/js/_url.js
@@ -55,10 +55,14 @@ function updateURL(optimize) {
 }
 
 function parseURL() {
-    var hash = window.location.hash;
+    var loc = window.location.toString();
+    var hash = null;
+    if (loc.indexOf('#') >= 0) {
+      hash = loc.substring(loc.indexOf('#') + 1);
+    }
 
     if (hash) {
-        options = URLON.parse(URLON.stringify(hash.replace("#", "")));
+        options = URLON.parse(hash);
 
         URL.state = options.state;
         URL.lang = options.lang;


### PR DESCRIPTION
In Firefox `window.location.hash` returns string that is already decoded,
so when you are try to use `encodeURI` function on this string you will get an error "Malformed URI sequence"
#163 