### PR TITLE
v0.8.3_05: Right closing line of drop down box is missing #692

### DIFF
--- a/src/components/buttonlist/dialogs/_dialog.scss
+++ b/src/components/buttonlist/dialogs/_dialog.scss
@@ -319,9 +319,12 @@
   }
 
   .vzb-ip-scaletype {
+    display: block !important;
     float: right;
     width: 100px;
     margin: 5px 10px 5px 0;
+    position: relative;
+    right: 23px;
   }
 }
 


### PR DESCRIPTION
changed the position of secondary select box. This should fix the issue with missing line as it should not run off the screen.