### PR TITLE
Issue #952: Rename use: "value" to use: "constant"

### DIFF
--- a/.data/waffles/metadata.json
+++ b/.data/waffles/metadata.json
@@ -157,7 +157,7 @@
         },
         "_default": {
             "allowCharts": ["*"],
-            "use": "value",
+            "use": "constant",
             "unit": "",
             "scales": ["ordinal"],
             "sourceLink": ""

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -470,7 +470,7 @@ var Model = Events.extend({
     filters = this._getAllFilters(exceptions, splashScreen);
     grouping = this._getGrouping();
 
-    if(this.use !== 'value') dimensions = dimensions.concat([this.which]);
+    if(this.use !== 'constant') dimensions = dimensions.concat([this.which]);
     select = utils.unique(dimensions);
 
     //return query
@@ -725,7 +725,7 @@ var Model = Events.extend({
       return;
     }
     var value;
-    if(this.use === 'value') {
+    if(this.use === 'constant') {
       value = this.which;
     } else if(this._space.hasOwnProperty(this.use)) {
       value = this._space[this.use][this.which];
@@ -1370,8 +1370,8 @@ function interpolatePoint(arr, use, which, i, dimTime, time, method) {
     utils.warn('interpolatePoint returning NULL: array is empty');
     return null;
   }
-  // return constant for the use of "value"
-  if(use === 'value') {
+  // return constant for the use of "constant"
+  if(use === 'constant') {
     return which;
   }
   // zero-order interpolation for the use of properties
@@ -1430,8 +1430,8 @@ function interpolateValue(_filter, use, which, l, method) {
     return null;
   }
 
-  // return constant for the use of "value"
-  if(use === 'value') {
+  // return constant for the use of "constant"
+  if(use === 'constant') {
     return items[0][which];
   }
 

--- a/src/components/buttonlist/dialogs/stack/stack.js
+++ b/src/components/buttonlist/dialogs/stack/stack.js
@@ -122,7 +122,7 @@ var Stack = Dialog.extend({
             if(value !== "all" && value !== "none"){
                 obj.stack.use = "property";
             } else {
-                obj.stack.use = "value";
+                obj.stack.use = "constant";
             }
         
             //validate possible merge values in group and stack hooks

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -30,7 +30,7 @@ var AxisModel = Model.extend({
    * Default values for this model
    */
   _defaults: {
-    use: "value",
+    use: "constant",
     which: undefined,
     min: null,
     max: null,
@@ -124,7 +124,7 @@ var AxisModel = Model.extend({
       case "property":
         domain = this.getUnique(this.which);
         break;
-      case "value":
+      case "constant":
       default:
         domain = [this.which];
         break;

--- a/src/models/color.js
+++ b/src/models/color.js
@@ -12,7 +12,7 @@ var ColorModel = Model.extend({
    * Default values for this model
    */
   _defaults: {
-    use: "value",
+    use: "constant",
     palette: null,
     which: undefined
   },
@@ -113,7 +113,7 @@ var ColorModel = Model.extend({
 
       if(palettes[this.which]) {
         this.palette = utils.clone(palettes[this.which]);
-      } else if(this.use === "value") {
+      } else if(this.use === "constant") {
         this.palette = {
           "_default": this.which
         };

--- a/src/models/size.js
+++ b/src/models/size.js
@@ -12,7 +12,7 @@ var SizeModel = Model.extend({
    * Default values for this model
    */
   _defaults: {
-    use: "value",
+    use: "constant",
     min: 0,
     max: 1,
     which: undefined
@@ -44,8 +44,8 @@ var SizeModel = Model.extend({
     if(this.max < this.min) this.set('min', this.max, true);
 
     //value must always be between min and max
-    if(this.use === "value" && this.which > this.max) this.which = this.max;
-    if(this.use === "value" && this.which < this.min) this.which = this.min;
+    if(this.use === "constant" && this.which > this.max) this.which = this.max;
+    if(this.use === "constant" && this.which < this.min) this.which = this.min;
     
     if(!this.scaleType) this.scaleType = 'linear';
     if(this.use === "property") this.scaleType = 'ordinal';
@@ -81,7 +81,7 @@ var SizeModel = Model.extend({
       case "property":
         domain = this.getUnique(this.which);
         break;
-      case "value":
+      case "constant":
       default:
         domain = [this.which];
         break;

--- a/src/models/stack.js
+++ b/src/models/stack.js
@@ -16,7 +16,7 @@ var StackModel = Model.extend({
    * Default values for this model
    */
   _defaults: {
-    use: "value",
+    use: "constant",
     which: undefined,
     merge: false
   },
@@ -44,13 +44,13 @@ var StackModel = Model.extend({
 
     //use must not be "indicator" 
     if(this.use === "indicator") {
-      utils.warn("stack model: use must not be 'indicator'. Resetting use to 'value' and which to '" + palettes._default)
-      this.use = "value";
+      utils.warn("stack model: use must not be 'indicator'. Resetting use to 'constant' and which to '" + palettes._default)
+      this.use = "constant";
       this.which = palettes._default;
     }
 
-    //if use is "value"
-    if(this.use === "value" && utils.values(palettes).indexOf(this.which) == -1) {
+    //if use is "constant"
+    if(this.use === "constant" && utils.values(palettes).indexOf(this.which) == -1) {
       utils.warn("stack model: the requested value '" + this.which + "' is not allowed. resetting to '" +
         palettes._default)
       this.which == palettes._default;

--- a/src/vizabi-gapminder.js
+++ b/src/vizabi-gapminder.js
@@ -314,7 +314,7 @@ MountainChart.define('default_options', {
         }
       },
       stack: {
-        use: "value",
+        use: "constant",
         which: "all" // set a property of data or values "all" or "none"
       },
       group: {
@@ -568,7 +568,7 @@ PopByAge.define('default_options', {
         which: "pop"
       },
       color: {
-        use: "value",
+        use: "constant",
         which: "#ffb600"
       }
     }


### PR DESCRIPTION
Renames "value" to "constant" when defining the use property of models.