### PR TITLE
Issue #1069: Add Safari 8 autoprefix support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,9 @@ function compileSass(src, dest) {
       style: 'compact'
     })
     .on('error', sass.logError)
-    .pipe(prefix("last 1 version", "> 1%", "ie 8", "ie 7"))
+    .pipe(prefix({
+      browsers: ["last 1 version", "> 1%", "ie 8", "ie 7", "safari 8"]
+    }))
     .pipe(minifycss())
     .pipe(gulp.dest(dest));
 }


### PR DESCRIPTION
Fixes autoprefixing for specified browsers, like IE7 and IE8.

Adds Safari 8 support.