### PR TITLE
Deselect All” and “OK” are missing on Safari

### DIFF
--- a/src/components/buttonlist/dialogs/find/_find.scss
+++ b/src/components/buttonlist/dialogs/find/_find.scss
@@ -10,11 +10,11 @@
   }
 }
 
-//responsiveness      
+//responsiveness
 &.vzb-large {
   &.vzb-button-expand-true {
     .vzb-buttonlist-dialog {
-      &.vzb-dialog-side { 
+      &.vzb-dialog-side {
         &[data-btn="find"] {
           display: flex;
           flex-direction: column;
@@ -22,34 +22,35 @@
 
           .vzb-dialog-buttons {
             display: block;
+            flex: none;
           }
-      
+
           .vzb-dialog-button.vzb-label-primary {
-            visibility: hidden;
+            display: none;
           }
 
           .vzb-dialog-content {
             flex-grow: 1;
-              
+
             .vzb-dialog-content-fixed {
               height: 310px;
               max-height: 305px;
               min-width: 140px;
             }
           }
-          
+
           .vzb-dialog-title {
-            flex-grow: 0;
             display: inline-block;
-            padding: 15px 0 10px 20px;
+            padding: 0 0 0 20px;
             vertical-align: top;
             margin-top: 0;
+            flex: none;
           }
-          
+
           .vzb-find-filter {
             display: inline-block;
             position: relative;
-            padding: 10px;
+            padding: 0 10px;
             max-width: 210px;
             top: 0;
           }


### PR DESCRIPTION
Ugly overlapping in "find" menu on Safari