### PR TITLE
Bug/issue 1169

### DIFF
--- a/src/tools/bubblechart/bubblechart-panzoom.js
+++ b/src/tools/bubblechart/bubblechart-panzoom.js
@@ -25,7 +25,6 @@ export default Class.extend({
         this.zoomer.ratioY = 1;
     },
 
-
     drag: function(){
         var _this = this.context;
         var self = this;
@@ -84,7 +83,6 @@ export default Class.extend({
         };
     },
 
-
     zoom: function() {
         var _this = this.context;
         var zoomer = this.zoomer;
@@ -95,7 +93,6 @@ export default Class.extend({
 
                 if(d3.event.sourceEvent != null && (d3.event.sourceEvent.ctrlKey || d3.event.sourceEvent.metaKey)) return;
 
-                //console.log("zoom")
                 //send the event to the page if fully zoomed our or page not scrolled into view
 //
 //                    if(d3.event.scale == 1)
@@ -119,8 +116,6 @@ export default Class.extend({
                 var pan = d3.event.translate;
                 var ratioY = zoomer.ratioY;
                 var ratioX = zoomer.ratioX;
-
-                // console.log(d3.event.scale, zoomer.ratioY, zoomer.ratioX)
 
                 _this.draggingNow = true;
 
@@ -252,10 +247,6 @@ export default Class.extend({
         };
     },
 
-
-
-
-
     expandCanvas: function() {
         var _this = this.context;
 
@@ -310,7 +301,6 @@ export default Class.extend({
             //console.log("no rezoom")
         }
     },
-
 
     zoomToMaxMin: function(fakeMinX, fakeMaxX, fakeMinY, fakeMaxY, duration){
         var _this = this.context;
@@ -409,7 +399,6 @@ export default Class.extend({
 
     },
 
-
     _zoomOnRectangle: function(element, x1, y1, x2, y2, compensateDragging, duration) {
         var _this = this.context;
         var zoomer = this.zoomer;
@@ -458,7 +447,4 @@ export default Class.extend({
         this.zoomer.duration = 0;
         this.zoomer.event(element || _this.element);
     }
-
-
-
 });

--- a/src/tools/bubblechart/bubblechart-panzoom.js
+++ b/src/tools/bubblechart/bubblechart-panzoom.js
@@ -123,8 +123,19 @@ export default Class.extend({
                 if(isNaN(zoom) || zoom == null) zoom = zoomer.scale();
                 if(isNaN(zoom) || zoom == null) zoom = 1;
 
+                var sourceEvent = d3.event.sourceEvent;
+
                 //TODO: this is a patch to fix #221. A proper code review of zoom and zoomOnRectangle logic is needed
-                if(zoom == 1) {
+                /*
+                 * Mouse wheel and touchmove events set the zoom value
+                 * independently of axis ratios. If the zoom event was triggered
+                 * by a mouse wheel event scrolling down or touchmove event with
+                 * more than 1 contact that sets zoom to 1, then set the axis
+                 * ratios to 1 as well, which will fully zoom out.
+                 */
+                if(zoom === 1 && sourceEvent !== null &&
+                    (sourceEvent.type === "wheel" && sourceEvent.deltaY > 0 ||
+                     sourceEvent.type === "touchmove" && sourceEvent.touches.length > 1)) {
                     zoomer.ratioX = 1;
                     ratioX = 1;
                     zoomer.ratioY = 1;


### PR DESCRIPTION
When the difference between x1 and x2 is the same as the container's width, or
when the difference between y1 and y2 is the same as the container's height,
_zoomOnRectangle will set zoom to 1, but change the value of ratioX or ratioY
when trying to zoom.

However, in the zoom function, a hack is in place to reset the ratios to 1 when
zoom is 1, which prevents zooming under the above conditions.

If the above hack is removed, then it becomes possible to zoom in under the
above conditions, but impossible to zoom out with the mousewheel because zoom
is already at 1.

This commit changes the ratio reset conditions such that the ratios are only
reset when zooming out with mouse wheel or touch move events. Both events
independently set the zoom and pan values before the zoom.go() method is called,
but will leave the ratio values alone. If either event sets zoom to 1, the
minimal zoom amount, then we set the axis ratio values to 1. Doing so enables
zooming in under the above conditions and zooming out.