### PR TITLE
Feature/issue 1458

### DIFF
--- a/src/tools/bubblechart/bubblechart-component.js
+++ b/src/tools/bubblechart/bubblechart-component.js
@@ -385,6 +385,11 @@ var BubbleChartComp = Component.extend({
       .on("mouseup", function() {
         _this.draggingNow = false;
       })
+      .on("click", function() {
+        if (!d3.event.defaultPrevented && _this.model.ui.cursorMode === "minus") {
+          _this._panZoom.zoomOutIncrement();
+        }
+      });
 
     d3.select(this.parent.placeholder)
       .onTap(function() {

--- a/src/tools/bubblechart/bubblechart-component.js
+++ b/src/tools/bubblechart/bubblechart-component.js
@@ -138,7 +138,7 @@ var BubbleChartComp = Component.extend({
           _this.model.marker.getFrame(time, function(frame, time) {
             if (!frame) return false;
             var index = _this.calculationQueue.indexOf(time.toString()); //
-            if (index == -1) { // we was receive more recent frame before so we pass this frame  
+            if (index == -1) { // we was receive more recent frame before so we pass this frame
               return;
             } else {
               _this.calculationQueue.splice(0, index + 1); // remove timestamps that added to queue before current timestamp
@@ -211,7 +211,7 @@ var BubbleChartComp = Component.extend({
 
     this.xAxis = axisSmart();
     this.yAxis = axisSmart();
-      
+
     _this.COLOR_BLACKISH = "#333";
     _this.COLOR_WHITEISH = "#fdfdfd";
 
@@ -454,7 +454,7 @@ var BubbleChartComp = Component.extend({
       if(_this.model.ui.chart.adaptMinMaxZoom) _this._panZoom.expandCanvas();
     });
   },
-    
+
     /*
      * Zoom to the min and max values given in the URL axes markers.
      */
@@ -981,7 +981,7 @@ var BubbleChartComp = Component.extend({
   updateMarkerSizeLimits: function() {
     var _this = this;
     var extent = this.model.marker.size.extent || [0,1];
-      
+
     var minRadius = this.activeProfile.minRadius;
     var maxRadius = this.activeProfile.maxRadius;
 
@@ -999,7 +999,7 @@ var BubbleChartComp = Component.extend({
   updateLabelSizeLimits: function() {
     var _this = this;
     var extent = this.model.marker.size_label.extent || [0,1];
-      
+
     var minLabelTextSize = this.activeProfile.minLabelTextSize;
     var maxLabelTextSize = this.activeProfile.maxLabelTextSize;
     var minMaxDelta = maxLabelTextSize - minLabelTextSize;
@@ -1072,7 +1072,7 @@ var BubbleChartComp = Component.extend({
     }
     this.model.marker.getFrame(time, function(valuesLocked) {
       if(!valuesLocked) return utils.warn("redrawDataPointsOnlySize: empty data received from marker.getFrames(). doing nothing");
-        
+
       valuesNow = _this.frame;
       _this.entityBubbles.each(function(d, index) {
 
@@ -1127,7 +1127,7 @@ var BubbleChartComp = Component.extend({
     var _this = this;
     var KEY = this.KEY;
     if(duration == null) duration = _this.duration;
-      
+
     if(this.model.ui.chart.lockNonSelected && this.someSelected) {
         var time = this.model.time.timeFormat.parse("" + this.model.ui.chart.lockNonSelected);
 
@@ -1153,7 +1153,7 @@ var BubbleChartComp = Component.extend({
   _updateBubble: function(d, values, index, view, duration) {
     var _this = this;
     var KEY = this.KEY;
-      
+
     var showhide = false;
 
     var valueY = values.axis_y[d[KEY]];
@@ -1170,14 +1170,14 @@ var BubbleChartComp = Component.extend({
            d.hidden = true;
            showhide = true;
        }
-        
+
       if(showhide) view.classed("vzb-invisible", d.hidden);
     } else {
         if(d.hidden || view.classed("vzb-invisible")) {
            d.hidden = false;
            showhide = true;
        }
-    
+
 
       // if entity has all the data we update the visuals
       var scaledS = utils.areaToRadius(_this.sScale(valueS));
@@ -1193,16 +1193,16 @@ var BubbleChartComp = Component.extend({
                 //to avoid transition from null state show entity with a delay if it was hidden
                 if(showhide) view.classed("vzb-invisible", d.hidden);
             })
-        
+
       } else {
-        
+
         //interrupt the ongoing transition and immediately do the visual updates
         view.interrupt()
           .attr("cy", _this.yScale(valueY))
           .attr("cx", _this.xScale(valueX))
           .attr("r", scaledS);
-          
-        //show entity if it was hidden  
+
+        //show entity if it was hidden
         if(showhide) view.classed("vzb-invisible", d.hidden);
       }
 
@@ -1217,7 +1217,7 @@ var BubbleChartComp = Component.extend({
       });
 
     } // data exists
-      
+
     _this._updateLabel(d, index, valueX, valueY, scaledS, valueL, valueLST, duration, showhide);
   },
 
@@ -1239,7 +1239,7 @@ var BubbleChartComp = Component.extend({
         return f[KEY] == d[KEY]
       });
       var trailStartTime = _this.model.time.timeFormat.parse("" + select.trailStartTime);
-        
+
       var brokenInputs = !valueX && valueX !==0 || !valueY && valueY !==0 || !scaledS && scaledS !==0;
 
       if(!brokenInputs && (!_this.model.ui.chart.trails || trailStartTime - _this.time > 0 || select.trailStartTime == null)) {
@@ -1274,18 +1274,18 @@ var BubbleChartComp = Component.extend({
 
           var text = labelGroup.selectAll(".vzb-bc-label-content")
             .text(valueL + (_this.model.ui.chart.trails ? " " + select.trailStartTime : ""));
-          
+
           var labels = _this.model.ui.chart.labels;
           labelGroup.classed('vzb-label-boxremoved', labels.removeLabelBox);
           var fontSize = _this.labelSizeTextScale(valueLST) + 'px';
           text.attr('font-size', fontSize);
-          
+
           var rect = labelGroup.select("rect");
 
           var contentBBox = text[0][0].getBBox();
           if(!cached.contentBBox || cached.contentBBox.width != contentBBox.width) {
             cached.contentBBox = contentBBox;
-            
+
             var labelCloseHeight = _this.activeProfile.infoElHeight * 1.2;//contentBBox.height;
 
             var labelCloseGroup = labelGroup.select(".vzb-bc-label-x")
@@ -1311,7 +1311,7 @@ var BubbleChartComp = Component.extend({
               .attr("rx", contentBBox.height * .2)
               .attr("ry", contentBBox.height * .2);
           }
-          
+
           var labelOffset = select.labelOffset || [0,0];
 
           cached.labelX_ = labelOffset[0] || (-cached.scaledS0 * .75 - 5) / _this.width;
@@ -1323,8 +1323,8 @@ var BubbleChartComp = Component.extend({
           var resolvedY = resolvedY0 + cached.labelY_ * _this.height;
 
           if(showhide && d.hidden && _this.model.ui.chart.trails && trailStartTime && (trailStartTime < _this.time)) showhide = false;
-          if(d.hidden && !_this.model.ui.chart.trails) showhide = true;  
-          
+          if(d.hidden && !_this.model.ui.chart.trails) showhide = true;
+
           _this._repositionLabels(d, index, this, resolvedX, resolvedY, resolvedX0, resolvedY0, duration, showhide, lineGroup);
 
         })
@@ -1342,7 +1342,7 @@ var BubbleChartComp = Component.extend({
     var cache = this.cached[d[this.KEY]];
 
     var labelGroup = d3.select(context);
-          
+
     //protect label and line from the broken data
     var brokenInputs = !_X && _X !==0 || !_Y && _Y !==0 || !_X0 && _X0 !==0 || !_Y0 && _Y0 !==0;
     if(brokenInputs) {
@@ -1405,8 +1405,8 @@ var BubbleChartComp = Component.extend({
     var labels = this.model.ui.chart.labels;
 
     var bBox = labels.removeLabelBox ? textBBox : rectBBox;
-    
-    var lineHidden = this.circleRectIntersects({x: diffX1, y: diffY1, r: cache.scaledS0}, 
+
+    var lineHidden = this.circleRectIntersects({x: diffX1, y: diffY1, r: cache.scaledS0},
       {x: diffX2, y: diffY2, width: (bBox.height * 2 + bBox.width), height: (bBox.height * 3)});
     lineGroup.select('line').classed("vzb-invisible", lineHidden);
     if(lineHidden) return;
@@ -1415,10 +1415,10 @@ var BubbleChartComp = Component.extend({
       var angle = Math.atan2(diffX1 - diffX2, diffY1 - diffY2) * 180 / Math.PI;
       var deltaDiffX2 = (angle >= 0 && angle <= 180) ? (bBox.width * .5) : (-bBox.width * .5);
       var deltaDiffY2 = (Math.abs(angle) <= 90) ? (bBox.height * .55) : (-bBox.height * .45);
-      diffX2 += Math.abs(diffX1 - diffX2) > textBBox.width * .5 ? deltaDiffX2 : 0; 
+      diffX2 += Math.abs(diffX1 - diffX2) > textBBox.width * .5 ? deltaDiffX2 : 0;
       diffY2 += Math.abs(diffY1 - diffY2) > textBBox.height * .5 ? deltaDiffY2 : (textBBox.height * .05);
     }
-          
+
     var longerSideCoeff = Math.abs(diffX1) > Math.abs(diffY1) ? Math.abs(diffX1) / this.width : Math.abs(diffY1) / this.height;
     lineGroup.select("line").style("stroke-dasharray", "0 " + (cache.scaledS0 + 2) + " " + ~~(longerSideCoeff + 2) + "00%");
 
@@ -1429,17 +1429,17 @@ var BubbleChartComp = Component.extend({
       .attr("y2", diffY2);
 
   },
- 
+
   /*
-   * Adapted from 
+   * Adapted from
    * http://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
-   * 
-   * circle { 
-   *  x: center X 
+   *
+   * circle {
+   *  x: center X
    *  y: center Y
    *  r: radius
    * }
-   * 
+   *
    * rect {
    *  x: center X
    *  y: center Y
@@ -1449,14 +1449,14 @@ var BubbleChartComp = Component.extend({
    */
   circleRectIntersects: function(circle, rect) {
     var circleDistanceX = Math.abs(circle.x - rect.x);
-    var circleDistanceY = Math.abs(circle.y - rect.y);    
+    var circleDistanceY = Math.abs(circle.y - rect.y);
     var halfRectWidth = rect.width * .5;
     var halfRectHeight = rect.height * .5;
 
     if (circleDistanceX > (halfRectWidth + circle.r)) { return false; }
     if (circleDistanceY > (halfRectHeight + circle.r)) { return false; }
 
-    if (circleDistanceX <= halfRectWidth) { return true; } 
+    if (circleDistanceX <= halfRectWidth) { return true; }
     if (circleDistanceY <= halfRectHeight) { return true; }
 
     var cornerDistance_sq = Math.pow(circleDistanceX - halfRectWidth, 2) +
@@ -1712,11 +1712,11 @@ var BubbleChartComp = Component.extend({
           var y = _this.yScale(values.axis_y[d[KEY]]);
           var s = utils.areaToRadius(_this.sScale(values.size[d[KEY]]));
           var entityOutOfView = false;
-          
+
           if(x + s < 0 || x - s > _this.width || y + s < 0 || y - s > _this.height) {
             entityOutOfView = true;
           }
-          
+
           //show tooltip
           var text = "";
           var hoverTrail = false;

--- a/src/tools/bubblechart/bubblechart-panzoom.js
+++ b/src/tools/bubblechart/bubblechart-panzoom.js
@@ -312,7 +312,7 @@ export default Class.extend({
         var mmX = d3.extent(utils.values(_this.frame.axis_x));
         var mmY = d3.extent(utils.values(_this.frame.axis_y));
         var radiusMax = utils.areaToRadius(_this.sScale( d3.extent(utils.values(_this.frame.size))[1] )) || 0;
-        
+
         //protection agains unreasonable min-max results -- abort function
         if (!mmX[0] && mmX[0]!==0 || !mmX[1] && mmX[1]!==0 || !mmY[0] && mmY[0]!==0 || !mmY[1] && mmY[1]!==0) {
           return utils.warn("panZoom.expandCanvas: X or Y min/max are broken. Aborting with no action");
@@ -576,7 +576,7 @@ export default Class.extend({
         var scalar = scaleDifference / Math.abs(dataBoundary - viewportBoundary);
         return (coordValue - dataBoundary) * (1 - scalar) + dataBoundary;
     },
-    
+
     /*
      * Reset zoom values without triggering a zoom event.
      */

--- a/src/tools/bubblechart/bubblechart-panzoom.js
+++ b/src/tools/bubblechart/bubblechart-panzoom.js
@@ -11,6 +11,8 @@ export default Class.extend({
         this.dragRectangle = d3.behavior.drag();
         this.zoomer = d3.behavior.zoom();
 
+        this.dragLock = false;
+
         this.dragRectangle
             .on("dragstart", this.drag().start)
             .on("drag", this.drag().go)
@@ -33,19 +35,43 @@ export default Class.extend({
 
         return {
             start: function(d, i) {
-                if(!(d3.event.sourceEvent.ctrlKey || d3.event.sourceEvent.metaKey)) return;
+                /*
+                 * Do not drag if the Ctrl key, Meta key, or plus cursor mode is
+                 * not enabled. Also do not drag if zoom-pinching on touchmove
+                 * events.
+                 */
+                if(!(d3.event.sourceEvent.ctrlKey || d3.event.sourceEvent.metaKey ||
+                     _this.ui.cursorMode === "plus") ||
+                     (d3.event.sourceEvent.type === "touchmove" || d3.event.sourceEvent.type === "touchstart") &&
+                     (d3.event.sourceEvent.touches.length > 1 || d3.event.sourceEvent.targetTouches.length > 1)) {
+                    return;
+                }
 
-                this.ctrlKeyLock = true;
+                self.dragLock = true;
                 this.origin = {
                     x: d3.mouse(this)[0],
                     y: d3.mouse(this)[1]
                 };
                 _this.zoomRect.classed("vzb-invisible", false);
-
             },
 
             go: function(d, i) {
-                if(!this.ctrlKeyLock) return;
+                /*
+                 * Cancel drag if drag lock is false, or when zoom-pinching via
+                 * touchmove events.
+                 */
+                if(!self.dragLock || (d3.event.sourceEvent.type === "touchmove" || d3.event.sourceEvent.type === "touchstart") &&
+                    (d3.event.sourceEvent.touches.length > 1 || d3.event.sourceEvent.targetTouches.length > 1)) {
+                    self.dragLock = false;
+
+                    _this.zoomRect
+                        .attr("width", 0)
+                        .attr("height", 0)
+                        .classed("vzb-invisible", true);
+
+                    return;
+                }
+
                 var origin = this.origin;
                 var mouse = {
                     x: d3.event.x,
@@ -60,8 +86,8 @@ export default Class.extend({
             },
 
             stop: function(e) {
-                if(!this.ctrlKeyLock) return;
-                this.ctrlKeyLock = false;
+                if(!self.dragLock) return;
+                self.dragLock = false;
 
                 _this.zoomRect
                     .attr("width", 0)
@@ -73,13 +99,21 @@ export default Class.extend({
                     y: d3.mouse(this)[1]
                 };
 
+                /*
+                 * Only compensate for dragging when the Ctrl key or Meta key
+                 * are pressed, or if the cursorMode is not in plus mode.
+                 */
+                var compensateDragging = d3.event.sourceEvent.ctrlKey ||
+                    d3.event.sourceEvent.metaKey ||
+                    _this.ui.cursorMode === "plus";
+
                 self._zoomOnRectangle(
                     d3.select(this),
                     this.origin.x,
                     this.origin.y,
                     this.target.x,
                     this.target.y,
-                    true, 500
+                    compensateDragging, 500
                 );
             }
         };
@@ -93,7 +127,18 @@ export default Class.extend({
         return {
             go: function() {
 
-                if(d3.event.sourceEvent != null && (d3.event.sourceEvent.ctrlKey || d3.event.sourceEvent.metaKey)) return;
+                var sourceEvent = d3.event.sourceEvent;
+
+                if(sourceEvent != null && (sourceEvent.ctrlKey || sourceEvent.metaKey)) return;
+
+                // Cancel drag lock when zoom-pinching via touchmove events.
+                if (sourceEvent !== null &&
+                    (sourceEvent.type === "touchmove" || sourceEvent.type === "touchstart") &&
+                    (sourceEvent.touches.length > 1 || sourceEvent.targetTouches.length > 1)) {
+                    self.dragLock = false;
+                }
+
+                if (self.dragLock) return;
 
                 //send the event to the page if fully zoomed our or page not scrolled into view
 //
@@ -103,9 +148,23 @@ export default Class.extend({
 //                        _this.scrollableAncestor.scrollTop += d3.event.sourceEvent.deltaY;
 //                        return;
 //                    }
-                if(d3.event.sourceEvent != null && _this.scrollableAncestor) {
-                    if(d3.event.sourceEvent != null && !self.enabled){
-                        _this.scrollableAncestor.scrollTop += d3.event.sourceEvent.deltaY;
+                /*
+                 * Do not zoom on the chart if the scroll event is a wheel
+                 * scroll. Instead, redirect the scroll event to the scrollable
+                 * ancestor
+                 */
+                if (sourceEvent != null && _this.ui.zoomOnScrolling &&
+                    sourceEvent.type === "wheel") {
+                    if (_this.scrollableAncestor && !self.enabled) {
+                        _this.scrollableAncestor.scrollTop += sourceEvent.deltaY;
+                    }
+
+                    return;
+                }
+
+                if(sourceEvent != null && _this.scrollableAncestor) {
+                    if(sourceEvent != null && !self.enabled){
+                        _this.scrollableAncestor.scrollTop += sourceEvent.deltaY;
                         zoomer.scale(1)
                         return;
                     }
@@ -124,8 +183,6 @@ export default Class.extend({
                 //value protections and fallbacks
                 if(isNaN(zoom) || zoom == null) zoom = zoomer.scale();
                 if(isNaN(zoom) || zoom == null) zoom = 1;
-
-                var sourceEvent = d3.event.sourceEvent;
 
                 //TODO: this is a patch to fix #221. A proper code review of zoom and zoomOnRectangle logic is needed
                 /*
@@ -575,6 +632,92 @@ export default Class.extend({
     _scaleCoordinate: function(coordValue, scaleDifference, dataBoundary, viewportBoundary) {
         var scalar = scaleDifference / Math.abs(dataBoundary - viewportBoundary);
         return (coordValue - dataBoundary) * (1 - scalar) + dataBoundary;
+    },
+
+    /*
+     * Calculate a proportional reduction of the scalar value. Also,
+     * calculate the reduction of the value by a constant of 1.
+     *
+     * Return the larger of the two calculated values.
+     */
+    _scaleToMin: function(scalar, minScalar, proportion, constant) {
+        var scalarProportionDelta = (scalar - minScalar) * proportion;
+        var scalarDifferenceDelta = Math.max(constant, minScalar - constant);
+        var scalarDelta = Math.max(scalarProportionDelta, scalarDifferenceDelta);
+
+        return scalarDelta;
+    },
+
+    /*
+     * Incrementally zoom out of the current zoom rectangle by a proportion. If
+     * the calculated zoom rectangle would cause the zoom scalar to be less than
+     * or equal to its minimum zoom value, then completely zoom out.
+     */
+    zoomOutIncrement: function(element) {
+        var _this = this.context;
+
+        var zoomRatio = 0.75;
+        var zoomDuration = 500;
+        var zoom = this.zoomer.scale();
+        var minZoom = this.zoomer.scaleExtent()[0];
+
+        /*
+         * Calculate a proportional reduction in zoom (currently 75%). Also,
+         * calculate the reduction of zoom by a constant of 1.
+         *
+         * Zoom out to the larger of the proportional zoom and constant
+         * difference zoom.
+         */
+        var zoomDelta = this._scaleToMin(zoom, minZoom, zoomRatio, minZoom);
+
+        /*
+         * If the calculated zoom delta is less than or equal to the minimum
+         * completely zoom out.
+         */
+        if (zoomDelta <= minZoom) {
+            this.resetZoomState();
+            this.zoomer.duration = zoomDuration;
+            this.zoomer.event(element || _this.element);
+            return;
+        }
+
+        var xBounds = [0, _this.width];
+        var yBounds = [_this.height, 0];
+
+        var xBoundsBumped = _this._rangeBump(xBounds);
+        var yBoundsBumped = _this._rangeBump(yBounds);
+
+        var xScaleBoundsBumped = _this.xScale.copy()
+            .range(xBoundsBumped);
+        var yScaleBoundsBumped = _this.yScale.copy()
+            .range(yBoundsBumped);
+
+        var xDataBounds = [xScaleBoundsBumped.invert(xBounds[0]), xScaleBoundsBumped.invert(xBounds[1])];
+        var yDataBounds = [yScaleBoundsBumped.invert(yBounds[0]), yScaleBoundsBumped.invert(yBounds[1])];
+
+        var xValues = [_this.xScale.invert(xBounds[0]), _this.xScale.invert(xBounds[1])];
+        var yValues = [_this.yScale.invert(yBounds[0]), _this.yScale.invert(yBounds[1])];
+
+        /*
+         * Calculate the difference between the current data ranges and the
+         * maximum possible data range including the range bump.
+         *
+         * Proportionally reduce the difference by the zoom ratio and zoom out
+         * to the new calculated zoom rectangle.
+         */
+        var minDifferenceX = (xValues[0] - xDataBounds[0]) * zoomRatio;
+        var maxDifferenceX = (xDataBounds[1] - xValues[1]) * zoomRatio;
+
+        var minDifferenceY = (yDataBounds[0] - yValues[0]) * zoomRatio;
+        var maxDifferenceY = (yValues[1] - yDataBounds[1]) * zoomRatio;
+
+        var zoomedMinX = _this.xScale(xDataBounds[0] + minDifferenceX);
+        var zoomedMaxX = _this.xScale(xDataBounds[1] - maxDifferenceX);
+
+        var zoomedMinY = _this.yScale(yDataBounds[0] - minDifferenceY);
+        var zoomedMaxY = _this.yScale(yDataBounds[1] + maxDifferenceY);
+
+        this._zoomOnRectangle(_this.element, zoomedMinX, zoomedMinY, zoomedMaxX, zoomedMaxY, false, zoomDuration);
     },
 
     /*


### PR DESCRIPTION
Add support for zooming via the "plus" cursor mode for zooming. Allows zooming
in by drawing rectangles.

Add support for zooming out via the "minus" cursor mode and single-clicking.

Add support for disabling zooming via the scroll wheel. While such zooming is
disabled, scroll events should propagate to the bubble chart's scrollable
ancestor.