### PR TITLE
Bug/issue 1340

### DIFF
--- a/src/components/timeslider/timeslider.js
+++ b/src/components/timeslider/timeslider.js
@@ -186,7 +186,7 @@ var TimeSlider = Component.extend({
 
     //Slide
     this.slide.call(this.brush);
-      
+
     this.slider_outer.on("mousewheel", function () {
         //do nothing and dont pass the event on if we are currently dragging the slider
         if(_this.model.time.dragging){
@@ -196,7 +196,7 @@ var TimeSlider = Component.extend({
             return false;
         }
     });
-      
+
     this.slide.selectAll(".extent,.resize")
       .remove();
 
@@ -407,7 +407,7 @@ var TimeSlider = Component.extend({
         .interrupt()
         .interrupt('text')
         .transition('text');
-      this.valueText        
+      this.valueText
         .attr("transform", "translate(" + new_pos + "," + (this.height / 2) + ")")
         .text(this.model.time.timeFormat(value));
     }

--- a/src/components/timeslider/timeslider.js
+++ b/src/components/timeslider/timeslider.js
@@ -328,6 +328,9 @@ var TimeSlider = Component.extend({
       //set brushed properties
 
       if(d3.event.sourceEvent) {
+        // Prevent window scrolling on cursor drag in Chrome/Chromium.
+        d3.event.sourceEvent.preventDefault();
+
         _this.model.time.dragStart();
         var posX = utils.roundStep(Math.round(d3.mouse(this)[0]), precision);
         value = _this.xScale.invert(posX);

--- a/src/tools/bubblechart/bubblechart-panzoom.js
+++ b/src/tools/bubblechart/bubblechart-panzoom.js
@@ -359,8 +359,8 @@ export default Class.extend({
 
             stop: function(){
                 _this.draggingNow = false;
-                
-                if (this.quitZoom) return; 
+
+                if (this.quitZoom) return;
 
                 //Force the update of the URL and history, with the same values
                 _this.model.marker.axis_x.set(_this._zoomZoomedDomains.x, true, true);
@@ -553,7 +553,7 @@ export default Class.extend({
             zoomer.translate([
                 zoomer.translate()[0] + x1 - x2,
                 zoomer.translate()[1] + y1 - y2
-            ])
+            ]);
         }
 
         var xRangeBounds = [0, _this.width];


### PR DESCRIPTION
Block page scrolling when dragging the time slider by blocking default behavior
on the drag event. Also prevents page scrolling when dragging the time slider
in Chrome and Chromium.